### PR TITLE
Removes unused imports

### DIFF
--- a/iiif_pipeline/create_derivatives.py
+++ b/iiif_pipeline/create_derivatives.py
@@ -5,7 +5,6 @@ import os
 import re
 import subprocess
 
-from pathlib import Path
 from PIL import Image
 from PIL.TiffTags import TAGS
 

--- a/iiif_pipeline/create_manifest.py
+++ b/iiif_pipeline/create_manifest.py
@@ -3,7 +3,6 @@ import os
 
 from configparser import ConfigParser
 from iiif_prezi.factory import ManifestFactory
-from pathlib import Path
 from PIL import Image
 
 class ManifestMaker:


### PR DESCRIPTION
Removes `Path` imports, fixes #22 

Branched from #5, so wait until that's merged.