### PR TITLE
Adds replace functionality

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.tox
+.github
+.pytest*

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ You can then run the pipeline, mounting any local directories you need access to
 For example, the command above will mount `/local_files/` on your local machine
 to `/source_files/` in the running container and then execute `iiif_pipeline.py`:
 
-    $ docker run -v /local_files:/source_files iiif-pipeline python /source_files
+    $ docker run -v /local_files:/source_files iiif-pipeline python iiif-pipeline.py /source_files
 
 
 ## Requirements

--- a/README.md
+++ b/README.md
@@ -58,10 +58,11 @@ contains a subdirectory named `master` containing original TIFF files:
 
 This library is designed to be executed from the command line:
 
-    $ iiif-pipeline.py source_directory [--skip SKIP]
+    $ iiif-pipeline.py source_directory [--skip] [--replace]
 
-where `source_directory` is a path to the directory described above and the
-optional `--skip` flag will skip image files with filenames ending in `_001`.
+where `source_directory` is a path to the directory described, the
+optional `--skip` flag will skip image files with filenames ending in `_001`,
+and the optional `--replace` flag will replace existing files.
 
 
 ## Configuration

--- a/iiif-pipeline.py
+++ b/iiif-pipeline.py
@@ -4,10 +4,19 @@ from iiif_pipeline.pipeline import IIIFPipeline
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Generates JPEG2000 images from TIF files based on input and output directories.")
-    parser.add_argument("source_directory", help="A directory containing subdirectories (named using ref ids) for archival objects.")
-    parser.add_argument("--skip", action="store_true", help="Skip files ending in `_001` during derivative creation.")
-    parser.add_argument("--replace", action="store_true", help="Replace existing files.")
+    parser = argparse.ArgumentParser(
+        description="Generates JPEG2000 images from TIF files based on input and output directories.")
+    parser.add_argument(
+        "source_directory",
+        help="A directory containing subdirectories (named using ref ids) for archival objects.")
+    parser.add_argument(
+        "--skip",
+        action="store_true",
+        help="Skip files ending in `_001` during derivative creation.")
+    parser.add_argument(
+        "--replace",
+        action="store_true",
+        help="Replace existing files.")
     args = parser.parse_args()
     IIIFPipeline().run(args.source_directory, args.skip, args.replace)
 

--- a/iiif-pipeline.py
+++ b/iiif-pipeline.py
@@ -6,9 +6,10 @@ from iiif_pipeline.pipeline import IIIFPipeline
 def main():
     parser = argparse.ArgumentParser(description="Generates JPEG2000 images from TIF files based on input and output directories.")
     parser.add_argument("source_directory", help="A directory containing subdirectories (named using ref ids) for archival objects.")
-    parser.add_argument("--skip", help="Skips files ending in `_001` during derivative creation.")
+    parser.add_argument("--skip", action="store_true", help="Skip files ending in `_001` during derivative creation.")
+    parser.add_argument("--replace", action="store_true", help="Replace existing files.")
     args = parser.parse_args()
-    IIIFPipeline().run(args.source_directory, args.skip)
+    IIIFPipeline().run(args.source_directory, args.skip, args.replace)
 
 
 if __name__ == "__main__":

--- a/iiif_pipeline/clients.py
+++ b/iiif_pipeline/clients.py
@@ -56,18 +56,20 @@ class AWSClient:
             aws_secret_access_key=secret_key)
         self.bucket = bucket
 
-    def upload_files(self, files, destination_dir):
+    def upload_files(self, files, destination_dir, replace=False):
         """Iterates over directories and conditionally uploads files to S3.
 
         Args:
             files (list): Filepaths to be uploaded.
-            destination_dir: Path in the bucket in which the file should be stored.
+            destination_dir (str): Path in the bucket in which the file should be stored.
+            replace (bool): Upload files even if they exist.
         """
         for file in files:
             key = os.path.splitext(os.path.basename(file))[0]
-            if self.object_in_bucket(destination_dir, key):
-                # TODO: provide replace handling
-                pass
+            bucket_path = os.path.join(destination_dir, key)
+            if (self.object_in_bucket(bucket_path) and not replace):
+                raise FileExistsError(
+                    "Error uploading files to AWS: {} already exists in {}".format(bucket_path, self.bucket))
             else:
                 if file.endswith(".json"):
                     content_type = "application/json"
@@ -75,7 +77,7 @@ class AWSClient:
                     # TODO: evaluate if we need to use this library or if mimetypes will work?
                     content_type = magic.from_file(file, mime=True)
                 self.s3.meta.client.upload_file(
-                    file, self.bucket, os.path.join(destination_dir, key),
+                    file, self.bucket, bucket_path,
                     ExtraArgs={'ContentType': content_type})
 
     def object_in_bucket(self, destination_dir, key):

--- a/iiif_pipeline/derivatives.py
+++ b/iiif_pipeline/derivatives.py
@@ -37,7 +37,7 @@ def is_tiff(file):
     return True if content_type == "image/tiff" else False
 
 
-def create_jp2(files, derivative_dir, identifier, replace=False):
+def create_jp2(files, identifier, derivative_dir, replace=False):
     """Creates JPEG2000 files from TIFF files.
 
     The default options for conversion below are:

--- a/iiif_pipeline/derivatives.py
+++ b/iiif_pipeline/derivatives.py
@@ -61,14 +61,16 @@ def create_jp2(files, derivative_dir, identifier, replace=False):
         derivative_path = os.path.join(
             derivative_dir, "{}_{}.jp2".format(identifier, os.path.splitext(original_file)[0].split("_")[-1]))
         if (os.path.isfile(derivative_path) and not replace):
-            raise FileExistsError("Error creating JPEG2000: {} already exists".format(derivative_path))
+            raise FileExistsError(
+                "Error creating JPEG2000: {} already exists".format(derivative_path))
         else:
             if is_tiff(original_file):
                 try:
                     layers = calculate_layers(original_file)
                     cmd = "opj_compress -i {} -o {} -n {} {} -SOP".format(
                         original_file, derivative_path, layers, ' '.join(default_options))
-                    subprocess.check_output([cmd], stderr=subprocess.STDOUT, shell=True)
+                    subprocess.check_output(
+                        [cmd], stderr=subprocess.STDOUT, shell=True)
                 except Exception as e:
                     raise Exception(
                         "Error creating JPEG2000: {}".format(e)) from e
@@ -88,7 +90,8 @@ def create_pdf(files, identifier, pdf_dir, replace=False):
     """
     pdf_path = "{}.pdf".format(os.path.join(pdf_dir, identifier))
     if (os.path.isfile(pdf_path) and not replace):
-        raise FileExistsError("Error creating PDF: {} already exists".format(pdf_path))
+        raise FileExistsError(
+            "Error creating PDF: {} already exists".format(pdf_path))
     try:
         with open(pdf_path, "wb") as f:
             f.write(img2pdf.convert(files))

--- a/iiif_pipeline/manifests.py
+++ b/iiif_pipeline/manifests.py
@@ -19,7 +19,8 @@ class ManifestMaker:
         self.fac.set_base_image_uri(self.resource_url)
         self.fac.set_debug("error")
 
-    def create_manifest(self, files, image_dir, identifier, obj_data, replace=False):
+    def create_manifest(self, files, image_dir, identifier,
+                        obj_data, replace=False):
         """Method that runs the other methods to build a manifest file and populate
         it with information.
 
@@ -30,9 +31,11 @@ class ManifestMaker:
             obj_data (dict): Data about the archival object.
             replace (bool): Replace existing files.
         """
-        manifest_path = "{}.json".format(os.path.join(self.manifest_dir, identifier))
+        manifest_path = "{}.json".format(
+            os.path.join(self.manifest_dir, identifier))
         if (os.path.isfile(manifest_path) and not replace):
-            raise FileExistsError("Error creating manifest: {} already exists".format(manifest_path))
+            raise FileExistsError(
+                "Error creating manifest: {} already exists".format(manifest_path))
         page_number = 1
         manifest = self.fac.manifest(ident=identifier, label=obj_data["title"])
         manifest.set_metadata({"Date": obj_data["dates"]})

--- a/iiif_pipeline/manifests.py
+++ b/iiif_pipeline/manifests.py
@@ -19,7 +19,7 @@ class ManifestMaker:
         self.fac.set_base_image_uri(self.resource_url)
         self.fac.set_debug("error")
 
-    def create_manifest(self, files, image_dir, identifier, obj_data):
+    def create_manifest(self, files, image_dir, identifier, obj_data, replace=False):
         """Method that runs the other methods to build a manifest file and populate
         it with information.
 
@@ -28,7 +28,11 @@ class ManifestMaker:
             image_dir (str): Path to directory containing derivative image files.
             identifier (str): A unique identifier.
             obj_data (dict): Data about the archival object.
+            replace (bool): Replace existing files.
         """
+        manifest_path = "{}.json".format(os.path.join(self.manifest_dir, identifier))
+        if (os.path.isfile(manifest_path) and not replace):
+            raise FileExistsError("Error creating manifest: {} already exists".format(manifest_path))
         page_number = 1
         manifest = self.fac.manifest(ident=identifier, label=obj_data["title"])
         manifest.set_metadata({"Date": obj_data["dates"]})

--- a/iiif_pipeline/pipeline.py
+++ b/iiif_pipeline/pipeline.py
@@ -16,13 +16,13 @@ class IIIFPipeline:
         self.config = ConfigParser()
         self.config.read("local_settings.cfg")
 
-    def run(self, source_dir, skip):
+    def run(self, source_dir, skip, replace):
         """Instantiates and runs derivative creation, manifest creation, and AWS upload files.
 
         Args:
-            source_dir (str): A directory containing subdirectories (named using ref ids) for archival objects
-            skip (bool): Boolean that indicates whether the derivative creation script should skip
-                files ending with `_001`.
+            source_dir (str): A directory containing subdirectories (named using ref ids) for archival objects.
+            skip (bool): Flag to should skip files ending with `_001`.
+            replace (bool): Flag to replace existing files.
         """
         if not os.path.isdir(source_dir):
             raise Exception("{} is not a path to a directory.".format(source_dir))
@@ -52,19 +52,19 @@ class IIIFPipeline:
                     raise Exception("Object directory {} does not have a subdirectory named `master`".format(directory))
                 obj_data = as_client.get_object(ref_id)
                 identifier = shortuuid.uuid(name=obj_data["uri"])
-                create_jp2(matching_files(obj_source_dir, skip=skip, prepend=True), jp2_dir, identifier)
+                create_jp2(matching_files(obj_source_dir, skip=skip, prepend=True), jp2_dir, identifier, replace)
                 logging.info("JPEG2000 derivatives created for {}".format(identifier))
                 ManifestMaker(
                     self.config.get("ImageServer", "baseurl"), manifest_dir).create_manifest(
-                        matching_files(jp2_dir, prefix=identifier), jp2_dir, identifier, obj_data)
+                        matching_files(jp2_dir, prefix=identifier), jp2_dir, identifier, obj_data, replace)
                 logging.info("IIIF Manifest created for {}".format(identifier))
-                create_pdf(matching_files(jp2_dir, prefix=identifier, prepend=True), identifier, pdf_dir)
+                create_pdf(matching_files(jp2_dir, prefix=identifier, prepend=True), identifier, pdf_dir, replace)
                 logging.info("Concatenated PDF created for {}".format(identifier))
                 for src_dir, target_dir, file_type in [
                         (jp2_dir, "images", "JPEG2000 files"),
                         (pdf_dir, "pdfs", "PDF file"),
                         (manifest_dir, "manifests", "Manifest file")]:
-                    aws_client.upload_files(matching_files(src_dir, prefix=identifier, prepend=True), target_dir)
+                    aws_client.upload_files(matching_files(src_dir, prefix=identifier, prepend=True), target_dir, replace)
                     logging.info("{} uploaded for {}".format(file_type, identifier))
                 cleanup_files(identifier, [jp2_dir, pdf_dir, manifest_dir])
             except Exception as e:

--- a/iiif_pipeline/pipeline.py
+++ b/iiif_pipeline/pipeline.py
@@ -55,20 +55,44 @@ class IIIFPipeline:
                         "Object directory {} does not have a subdirectory named `master`".format(directory))
                 obj_data = as_client.get_object(ref_id)
                 identifier = shortuuid.uuid(name=obj_data["uri"])
-                create_jp2(matching_files(obj_source_dir, skip=skip, prepend=True), jp2_dir, identifier, replace)
-                logging.info("JPEG2000 derivatives created for {}".format(identifier))
+                create_jp2(
+                    matching_files(
+                        obj_source_dir,
+                        skip=skip,
+                        prepend=True),
+                    jp2_dir,
+                    identifier,
+                    replace)
+                logging.info(
+                    "JPEG2000 derivatives created for {}".format(identifier))
                 ManifestMaker(
                     self.config.get("ImageServer", "baseurl"), manifest_dir).create_manifest(
                         matching_files(jp2_dir, prefix=identifier), jp2_dir, identifier, obj_data, replace)
                 logging.info("IIIF Manifest created for {}".format(identifier))
-                create_pdf(matching_files(jp2_dir, prefix=identifier, prepend=True), identifier, pdf_dir, replace)
-                logging.info("Concatenated PDF created for {}".format(identifier))
+                create_pdf(
+                    matching_files(
+                        jp2_dir,
+                        prefix=identifier,
+                        prepend=True),
+                    identifier,
+                    pdf_dir,
+                    replace)
+                logging.info(
+                    "Concatenated PDF created for {}".format(identifier))
                 for src_dir, target_dir, file_type in [
                         (jp2_dir, "images", "JPEG2000 files"),
                         (pdf_dir, "pdfs", "PDF file"),
                         (manifest_dir, "manifests", "Manifest file")]:
-                    aws_client.upload_files(matching_files(src_dir, prefix=identifier, prepend=True), target_dir, replace)
-                    logging.info("{} uploaded for {}".format(file_type, identifier))
+                    aws_client.upload_files(
+                        matching_files(
+                            src_dir,
+                            prefix=identifier,
+                            prepend=True),
+                        target_dir,
+                        replace)
+                    logging.info(
+                        "{} uploaded for {}".format(
+                            file_type, identifier))
                 cleanup_files(identifier, [jp2_dir, pdf_dir, manifest_dir])
             except Exception as e:
                 print(e)

--- a/iiif_pipeline/pipeline.py
+++ b/iiif_pipeline/pipeline.py
@@ -55,41 +55,27 @@ class IIIFPipeline:
                         "Object directory {} does not have a subdirectory named `master`".format(directory))
                 obj_data = as_client.get_object(ref_id)
                 identifier = shortuuid.uuid(name=obj_data["uri"])
-                create_jp2(
-                    matching_files(
-                        obj_source_dir,
-                        skip=skip,
-                        prepend=True),
-                    jp2_dir,
-                    identifier,
-                    replace)
+                tiff_files = matching_files(
+                    obj_source_dir, skip=skip, prepend=True)
+                create_jp2(tiff_files, identifier, jp2_dir, replace)
                 logging.info(
                     "JPEG2000 derivatives created for {}".format(identifier))
                 ManifestMaker(
                     self.config.get("ImageServer", "baseurl"), manifest_dir).create_manifest(
                         matching_files(jp2_dir, prefix=identifier), jp2_dir, identifier, obj_data, replace)
                 logging.info("IIIF Manifest created for {}".format(identifier))
-                create_pdf(
-                    matching_files(
-                        jp2_dir,
-                        prefix=identifier,
-                        prepend=True),
-                    identifier,
-                    pdf_dir,
-                    replace)
+                jp2_files = matching_files(
+                    jp2_dir, prefix=identifier, prepend=True)
+                create_pdf(jp2_files, identifier, pdf_dir, replace)
                 logging.info(
                     "Concatenated PDF created for {}".format(identifier))
                 for src_dir, target_dir, file_type in [
                         (jp2_dir, "images", "JPEG2000 files"),
                         (pdf_dir, "pdfs", "PDF file"),
                         (manifest_dir, "manifests", "Manifest file")]:
-                    aws_client.upload_files(
-                        matching_files(
-                            src_dir,
-                            prefix=identifier,
-                            prepend=True),
-                        target_dir,
-                        replace)
+                    uploads = matching_files(
+                        src_dir, prefix=identifier, prepend=True)
+                    aws_client.upload_files(uploads, target_dir, replace)
                     logging.info(
                         "{} uploaded for {}".format(
                             file_type, identifier))

--- a/tests/test_create_jp2.py
+++ b/tests/test_create_jp2.py
@@ -1,4 +1,5 @@
 import os
+import pytest
 import random
 import shutil
 
@@ -10,7 +11,7 @@ from iiif_pipeline.helpers import matching_files
 FIXTURES_FILEPATH = os.path.join("fixtures", "tif")
 SOURCE_DIR = os.path.join("/", "source")
 DERIVATIVE_DIR = os.path.join("/", "derivatives")
-UUIDS = [random_string() for x in range(random.randint(1, 3))]
+UUIDS = [random_string() for x in range(random.randint(2, 3))]
 PAGE_COUNT = random.randint(1, 5)
 
 
@@ -26,10 +27,24 @@ def setup():
 
 def test_create_jp2():
     """Ensure the run method produces the expected number of files."""
-    create_jp2(matching_files(SOURCE_DIR, skip=False, prepend=True), DERIVATIVE_DIR, random.choice(UUIDS))
+    uuid = random.choice(UUIDS)
+    create_jp2(matching_files(SOURCE_DIR, prefix=uuid, skip=False, prepend=True), DERIVATIVE_DIR, uuid)
     assert len(os.listdir(DERIVATIVE_DIR)) == PAGE_COUNT
     for f in os.listdir(DERIVATIVE_DIR):
         assert ".tif" not in f
+
+
+def test_replace_jp2():
+    """Ensure replacing of files is handled correctly.
+
+    If files exist and the replace parameter is False, a FileExistsError should
+    be raised.
+    """
+    uuid = random.choice(UUIDS)
+    create_jp2(matching_files(SOURCE_DIR, prefix=uuid, skip=False, prepend=True), DERIVATIVE_DIR, uuid)
+    with pytest.raises(FileExistsError):
+        create_jp2(matching_files(SOURCE_DIR, prefix=uuid, skip=False, prepend=True), DERIVATIVE_DIR, uuid)
+    create_jp2(matching_files(SOURCE_DIR, prefix=uuid, skip=False, prepend=True), DERIVATIVE_DIR, uuid, replace=True)
 
 
 def teardown():

--- a/tests/test_create_jp2.py
+++ b/tests/test_create_jp2.py
@@ -1,8 +1,8 @@
 import os
-import pytest
 import random
 import shutil
 
+import pytest
 from helpers import copy_sample_files, random_string
 from iiif_pipeline.derivatives import create_jp2
 from iiif_pipeline.helpers import matching_files
@@ -27,7 +27,14 @@ def setup():
 def test_create_jp2():
     """Ensure the run method produces the expected number of files."""
     uuid = random.choice(UUIDS)
-    create_jp2(matching_files(SOURCE_DIR, prefix=uuid, skip=False, prepend=True), DERIVATIVE_DIR, uuid)
+    create_jp2(
+        matching_files(
+            SOURCE_DIR,
+            prefix=uuid,
+            skip=False,
+            prepend=True),
+        DERIVATIVE_DIR,
+        uuid)
     assert len(os.listdir(DERIVATIVE_DIR)) == PAGE_COUNT
     for f in os.listdir(DERIVATIVE_DIR):
         assert ".tif" not in f
@@ -40,10 +47,32 @@ def test_replace_jp2():
     be raised.
     """
     uuid = random.choice(UUIDS)
-    create_jp2(matching_files(SOURCE_DIR, prefix=uuid, skip=False, prepend=True), DERIVATIVE_DIR, uuid)
+    create_jp2(
+        matching_files(
+            SOURCE_DIR,
+            prefix=uuid,
+            skip=False,
+            prepend=True),
+        DERIVATIVE_DIR,
+        uuid)
     with pytest.raises(FileExistsError):
-        create_jp2(matching_files(SOURCE_DIR, prefix=uuid, skip=False, prepend=True), DERIVATIVE_DIR, uuid)
-    create_jp2(matching_files(SOURCE_DIR, prefix=uuid, skip=False, prepend=True), DERIVATIVE_DIR, uuid, replace=True)
+        create_jp2(
+            matching_files(
+                SOURCE_DIR,
+                prefix=uuid,
+                skip=False,
+                prepend=True),
+            DERIVATIVE_DIR,
+            uuid)
+    create_jp2(
+        matching_files(
+            SOURCE_DIR,
+            prefix=uuid,
+            skip=False,
+            prepend=True),
+        DERIVATIVE_DIR,
+        uuid,
+        replace=True)
 
 
 def teardown():

--- a/tests/test_create_jp2.py
+++ b/tests/test_create_jp2.py
@@ -27,14 +27,12 @@ def setup():
 def test_create_jp2():
     """Ensure the run method produces the expected number of files."""
     uuid = random.choice(UUIDS)
-    create_jp2(
-        matching_files(
-            SOURCE_DIR,
-            prefix=uuid,
-            skip=False,
-            prepend=True),
-        DERIVATIVE_DIR,
-        uuid)
+    tiff_files = matching_files(
+        SOURCE_DIR,
+        prefix=uuid,
+        skip=False,
+        prepend=True)
+    create_jp2(tiff_files, uuid, DERIVATIVE_DIR)
     assert len(os.listdir(DERIVATIVE_DIR)) == PAGE_COUNT
     for f in os.listdir(DERIVATIVE_DIR):
         assert ".tif" not in f
@@ -47,32 +45,15 @@ def test_replace_jp2():
     be raised.
     """
     uuid = random.choice(UUIDS)
-    create_jp2(
-        matching_files(
-            SOURCE_DIR,
-            prefix=uuid,
-            skip=False,
-            prepend=True),
-        DERIVATIVE_DIR,
-        uuid)
+    tiff_files = matching_files(
+        SOURCE_DIR,
+        prefix=uuid,
+        skip=False,
+        prepend=True)
+    create_jp2(tiff_files, uuid, DERIVATIVE_DIR)
     with pytest.raises(FileExistsError):
-        create_jp2(
-            matching_files(
-                SOURCE_DIR,
-                prefix=uuid,
-                skip=False,
-                prepend=True),
-            DERIVATIVE_DIR,
-            uuid)
-    create_jp2(
-        matching_files(
-            SOURCE_DIR,
-            prefix=uuid,
-            skip=False,
-            prepend=True),
-        DERIVATIVE_DIR,
-        uuid,
-        replace=True)
+        create_jp2(tiff_files, uuid, DERIVATIVE_DIR)
+    create_jp2(tiff_files, uuid, DERIVATIVE_DIR, replace=True)
 
 
 def teardown():

--- a/tests/test_create_pdf.py
+++ b/tests/test_create_pdf.py
@@ -1,4 +1,5 @@
 import os
+import pytest
 import random
 import shutil
 
@@ -29,6 +30,19 @@ def test_create_pdf():
     create_pdf(matching_files(DERIVATIVE_DIR, prefix=identifier, prepend=True), identifier, PDF_DIR)
     assert len(os.listdir(PDF_DIR)) == 1
     assert os.path.isfile(os.path.join(PDF_DIR, "{}.pdf".format(identifier)))
+
+
+def test_replace_pdf():
+    """Ensure replacing of files is handled correctly.
+
+    If files exist and the replace parameter is False, a FileExistsError should
+    be raised.
+    """
+    identifier = random.choice(UUIDS)
+    create_pdf(matching_files(DERIVATIVE_DIR, prefix=identifier, prepend=True), identifier, PDF_DIR)
+    with pytest.raises(FileExistsError):
+        create_pdf(matching_files(DERIVATIVE_DIR, prefix=identifier, prepend=True), identifier, PDF_DIR)
+    create_pdf(matching_files(DERIVATIVE_DIR, prefix=identifier, prepend=True), identifier, PDF_DIR, replace=True)
 
 
 def teardown():

--- a/tests/test_create_pdf.py
+++ b/tests/test_create_pdf.py
@@ -27,13 +27,11 @@ def setup():
 def test_create_pdf():
     """Ensure the run method produces the expected number of files."""
     identifier = random.choice(UUIDS)
-    create_pdf(
-        matching_files(
-            DERIVATIVE_DIR,
-            prefix=identifier,
-            prepend=True),
-        identifier,
-        PDF_DIR)
+    jp2_files = matching_files(
+        DERIVATIVE_DIR,
+        prefix=identifier,
+        prepend=True)
+    create_pdf(jp2_files, identifier, PDF_DIR)
     assert len(os.listdir(PDF_DIR)) == 1
     assert os.path.isfile(os.path.join(PDF_DIR, "{}.pdf".format(identifier)))
 
@@ -45,29 +43,14 @@ def test_replace_pdf():
     be raised.
     """
     identifier = random.choice(UUIDS)
-    create_pdf(
-        matching_files(
-            DERIVATIVE_DIR,
-            prefix=identifier,
-            prepend=True),
-        identifier,
-        PDF_DIR)
+    jp2_files = matching_files(
+        DERIVATIVE_DIR,
+        prefix=identifier,
+        prepend=True)
+    create_pdf(jp2_files, identifier, PDF_DIR)
     with pytest.raises(FileExistsError):
-        create_pdf(
-            matching_files(
-                DERIVATIVE_DIR,
-                prefix=identifier,
-                prepend=True),
-            identifier,
-            PDF_DIR)
-    create_pdf(
-        matching_files(
-            DERIVATIVE_DIR,
-            prefix=identifier,
-            prepend=True),
-        identifier,
-        PDF_DIR,
-        replace=True)
+        create_pdf(jp2_files, identifier, PDF_DIR)
+    create_pdf(jp2_files, identifier, PDF_DIR, replace=True)
 
 
 def teardown():

--- a/tests/test_create_pdf.py
+++ b/tests/test_create_pdf.py
@@ -1,8 +1,8 @@
 import os
-import pytest
 import random
 import shutil
 
+import pytest
 from helpers import copy_sample_files, random_string
 from iiif_pipeline.derivatives import create_pdf
 from iiif_pipeline.helpers import matching_files
@@ -45,10 +45,29 @@ def test_replace_pdf():
     be raised.
     """
     identifier = random.choice(UUIDS)
-    create_pdf(matching_files(DERIVATIVE_DIR, prefix=identifier, prepend=True), identifier, PDF_DIR)
+    create_pdf(
+        matching_files(
+            DERIVATIVE_DIR,
+            prefix=identifier,
+            prepend=True),
+        identifier,
+        PDF_DIR)
     with pytest.raises(FileExistsError):
-        create_pdf(matching_files(DERIVATIVE_DIR, prefix=identifier, prepend=True), identifier, PDF_DIR)
-    create_pdf(matching_files(DERIVATIVE_DIR, prefix=identifier, prepend=True), identifier, PDF_DIR, replace=True)
+        create_pdf(
+            matching_files(
+                DERIVATIVE_DIR,
+                prefix=identifier,
+                prepend=True),
+            identifier,
+            PDF_DIR)
+    create_pdf(
+        matching_files(
+            DERIVATIVE_DIR,
+            prefix=identifier,
+            prepend=True),
+        identifier,
+        PDF_DIR,
+        replace=True)
 
 
 def teardown():

--- a/tests/test_manifests.py
+++ b/tests/test_manifests.py
@@ -1,8 +1,8 @@
 import os
-import pytest
 import random
 import shutil
 
+import pytest
 from helpers import copy_sample_files, random_string
 from iiif_pipeline.helpers import matching_files
 from iiif_pipeline.manifests import ManifestMaker

--- a/tests/test_manifests.py
+++ b/tests/test_manifests.py
@@ -1,4 +1,5 @@
 import os
+import pytest
 import random
 import shutil
 
@@ -33,6 +34,28 @@ def test_create_manifest():
         {"title": random_string(), "dates": random_string()})
     assert len(os.listdir(MANIFEST_DIR)) == 1
     assert os.path.isfile(os.path.join(MANIFEST_DIR, "{}.json".format(uuid)))
+
+
+def test_replace_manifest():
+    """Ensure replacing of files is handled correctly.
+
+    If files exist and the replace parameter is False, a FileExistsError should
+    be raised.
+    """
+    uuid = random.choice(UUIDS)
+    ManifestMaker("http://example.com", MANIFEST_DIR).create_manifest(
+        matching_files(DERIVATIVE_DIR, prefix=uuid),
+        DERIVATIVE_DIR, uuid,
+        {"title": random_string(), "dates": random_string()})
+    with pytest.raises(FileExistsError):
+        ManifestMaker("http://example.com", MANIFEST_DIR).create_manifest(
+            matching_files(DERIVATIVE_DIR, prefix=uuid),
+            DERIVATIVE_DIR, uuid,
+            {"title": random_string(), "dates": random_string()})
+    ManifestMaker("http://example.com", MANIFEST_DIR).create_manifest(
+        matching_files(DERIVATIVE_DIR, prefix=uuid),
+        DERIVATIVE_DIR, uuid,
+        {"title": random_string(), "dates": random_string()}, replace=True)
 
 
 def teardown():

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -31,7 +31,7 @@ def test_pipeline(mock_aws_client, mock_get_object):
         {"title": random_string(), "dates": "1950-1951", "uri": random_string()},
         {"title": random_string(), "dates": "1945-1973", "uri": random_string()}]
     with archivesspace_vcr.use_cassette("get_ao.json"):
-        IIIFPipeline().run(SOURCE_DIR, False)
+        IIIFPipeline().run(SOURCE_DIR, False, False)
         for subpath in ["images", "pdfs", "manifests"]:
             assert os.path.isdir(os.path.join(SOURCE_DIR, subpath))
             assert len(os.listdir(os.path.join(SOURCE_DIR, subpath))) == 0
@@ -49,7 +49,7 @@ def test_pipeline_exception(mock_aws_client, mock_get_object, caplog):
     mock_get_object.return_value = {"title": random_string(), "dates": "1945-1950", "uri": random_string()}
     mock_aws_client.side_effect = Exception(exception_text)
     with archivesspace_vcr.use_cassette("get_ao.json"):
-        IIIFPipeline().run(SOURCE_DIR, False)
+        IIIFPipeline().run(SOURCE_DIR, False, False)
         assert len(caplog.records) == len(UUIDS)
         for log in caplog.records:
             assert log.getMessage() == exception_text


### PR DESCRIPTION
Adds a single `--replace` flag which will replace files locally and in AWS. I did this because I was having a hard time coming up with a use case where you'd want to do one and NOT the other - open to splitting those into two flags if you're seeing something I'm not.

Tests have been updated as well.

This is branched from `issue-45` so merge that first.

fixes #19 and fixes #23 