### PR TITLE
Converts manifests to v3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ pytest==4.3.0
 python-magic==0.4.18
 shortuuid==1.0.1
 vcrpy==4.1.0
+git+https://github.com/IIIF/prezi-2-to-3@6fb21e0643e47e7fb9cbf8468d5bfa0de258aa13


### PR DESCRIPTION
Add `iiif-prezi-upgrader` to convert manifests to IIIF v3.

fixes #12 