### PR TITLE
Simplify handling of mimetypes

### DIFF
--- a/iiif_pipeline/clients.py
+++ b/iiif_pipeline/clients.py
@@ -1,7 +1,6 @@
 import os
 
 import boto3
-import magic
 from asnake import utils
 from asnake.aspace import ASpace
 from botocore.exceptions import ClientError
@@ -73,12 +72,11 @@ class AWSClient:
                 raise FileExistsError(
                     "Error uploading files to AWS: {} already exists in {}".format(bucket_path, self.bucket))
             else:
+                content_type = "image/jp2"
                 if file.endswith(".json"):
                     content_type = "application/json"
-                else:
-                    # TODO: evaluate if we need to use this library or if
-                    # mimetypes will work?
-                    content_type = magic.from_file(file, mime=True)
+                elif file.endswith(".pdf"):
+                    content_type = "application/pdf"
                 self.s3.meta.client.upload_file(
                     file, self.bucket, bucket_path,
                     ExtraArgs={'ContentType': content_type})

--- a/iiif_pipeline/derivatives.py
+++ b/iiif_pipeline/derivatives.py
@@ -1,9 +1,9 @@
 import math
 import os
 import subprocess
+from mimetypes import MimeTypes
 
 import img2pdf
-import magic
 from PIL import Image
 
 
@@ -32,8 +32,7 @@ def is_tiff(file):
     Returns:
         boolean: True if tiff file, false otherwise.
     """
-    # TODO: evaluate if we can use mimetypes library instead
-    content_type = magic.from_file(file, mime=True)
+    content_type = MimeTypes().guess_type(file)[0]
     return True if content_type == "image/tiff" else False
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,5 @@ iiif-prezi==0.3.0
 img2pdf==0.4.0
 Pillow==8.0.1
 pytest==4.3.0
-python-magic==0.4.18
 shortuuid==1.0.1
 vcrpy==4.1.0


### PR DESCRIPTION
Removes the `magic` library and instead uses the built-in `mimetypes` library.

This does not catch all mimetypes, so instead of adding an additional library, I just used if/elif statements in the upload submodule, since at that point we know that all files will be either JSON, PDF or JPEG2000.