### PR TITLE
Add PDF compression with Ghostscript

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,8 @@ RUN apt-get update -y && apt-get install -y wget \
   make \
   pkg-config \
   libtiff-dev \
-  libmagic-dev
+  libmagic-dev \
+  ghostscript
 
 # Download and compile openjpeg2.1
 WORKDIR /tmp/openjpeg

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ to `/source_files/` in the running container and then execute `iiif_pipeline.py`
 The entire suite has the following system dependencies:
 - Python 3 (tested on Python 3.6)
 - OpenJPEG
+- Ghostscript
 
 It also requires these Python libraries in order to work correctly.
 - [ArchivesSnake](https://pypi.org/project/ArchivesSnake/)

--- a/iiif_pipeline/derivatives.py
+++ b/iiif_pipeline/derivatives.py
@@ -57,8 +57,8 @@ def create_jp2(files, identifier, derivative_dir, replace=False):
                        "-p RPCL"
                        ]
     for original_file in files:
-        derivative_path = os.path.join(
-            derivative_dir, "{}_{}.jp2".format(identifier, os.path.splitext(original_file)[0].split("_")[-1]))
+        derivative_path = os.path.join(derivative_dir, "{}_{}.jp2".format(
+            identifier, os.path.splitext(original_file)[0].split("_")[-1]))
         if (os.path.isfile(derivative_path) and not replace):
             raise FileExistsError(
                 "Error creating JPEG2000: {} already exists".format(derivative_path))
@@ -96,3 +96,24 @@ def create_pdf(files, identifier, pdf_dir, replace=False):
             f.write(img2pdf.convert(files))
     except Exception as e:
         raise Exception("Error creating PDF: {}".format(e)) from e
+
+
+def compress_pdf(identifier, pdf_dir):
+    """Compress PDF via Ghostscript command line interface and delete original PDF.
+    Delete original PDF when complete, replace compressed PDF with original filename.
+
+    Args:
+        identifier (str): Identifier of created PDF file.
+        pdf_dir (str): Directory in which to save the PDF file.
+    """
+    source_pdf_path = "{}.pdf".format(os.path.join(pdf_dir, identifier))
+    output_pdf_path = "{}_compressed.pdf".format(
+        os.path.join(pdf_dir, identifier))
+    subprocess.call(['gs', '-sDEVICE=pdfwrite', '-dCompatibilityLevel=1.4',
+                     '-dPDFSETTINGS={}'.format('/screen'),
+                     '-dNOPAUSE', '-dQUIET', '-dBATCH',
+                     '-sOutputFile={}'.format(output_pdf_path),
+                     source_pdf_path]
+                    )
+    os.remove(source_pdf_path)
+    os.rename(output_pdf_path, source_pdf_path)

--- a/iiif_pipeline/pipeline.py
+++ b/iiif_pipeline/pipeline.py
@@ -5,7 +5,7 @@ from configparser import ConfigParser
 import shortuuid
 
 from .clients import ArchivesSpaceClient, AWSClient
-from .derivatives import create_jp2, create_pdf
+from .derivatives import compress_pdf, create_jp2, create_pdf
 from .helpers import cleanup_files, matching_files, refid_dirs
 from .manifests import ManifestMaker
 
@@ -69,6 +69,9 @@ class IIIFPipeline:
                 create_pdf(jp2_files, identifier, pdf_dir, replace)
                 logging.info(
                     "Concatenated PDF created for {}".format(identifier))
+                compress_pdf(identifier, pdf_dir)
+                logging.info(
+                    "Compressed PDF created for {}".format(identifier))
                 for src_dir, target_dir, file_type in [
                         (jp2_dir, "images", "JPEG2000 files"),
                         (pdf_dir, "pdfs", "PDF file"),


### PR DESCRIPTION
Adds a function called after PDF creation to compress the PDF to a similar compression level as what we're currently using with Adobe. This compression greatly reduces the PDF file size. Deletes the uncompressed PDF, and renames the compressed PDF with the original PDF named. 

Fixes #58 