### PR TITLE
Improve logging format

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update -y && apt-get install -y wget \
 # Download and compile openjpeg2.1
 WORKDIR /tmp/openjpeg
 RUN git clone https://github.com/uclouvain/openjpeg.git ./
-RUN git checkout tags/version.2.1
+RUN git checkout tags/v2.3.1
 RUN cmake . && make && make install
 
 RUN mkdir /code

--- a/iiif_pipeline/pipeline.py
+++ b/iiif_pipeline/pipeline.py
@@ -12,8 +12,11 @@ from .manifests import ManifestMaker
 
 class IIIFPipeline:
     def __init__(self):
-        logfile = 'iiif_generation.log'
-        logging.basicConfig(filename=logfile, level=logging.INFO)
+        logging.basicConfig(
+            datefmt='%m/%d/%Y %I:%M:%S %p',
+            filename='iiif_generation.log',
+            format='%(asctime)s %(message)s',
+            level=logging.INFO)
         self.config = ConfigParser()
         self.config.read("local_settings.cfg")
 


### PR DESCRIPTION
Add timestamps to log format. Also updates to use latest version of OpenJPEG (which is what we're using in production).