### PR TITLE
Adds OCR layer and optimizes PDF using ocrmypdf

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,13 +11,19 @@ RUN apt-get update -y && apt-get install -y wget \
   pkg-config \
   libtiff-dev \
   libmagic-dev \
-  ghostscript
+  libleptonica-dev \
+  ocrmypdf
 
 # Download and compile openjpeg2.1
 WORKDIR /tmp/openjpeg
 RUN git clone https://github.com/uclouvain/openjpeg.git ./
 RUN git checkout tags/v2.3.1
 RUN cmake . && make && make install
+
+# Download and compile JBIG2 Encoder
+WORKDIR /tmp/jbig2enc
+RUN git clone https://github.com/agl/jbig2enc ./
+RUN ./autogen.sh && ./configure && make && make install
 
 RUN mkdir /code
 WORKDIR /code

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update -y && apt-get install -y wget \
   libtiff-dev \
   libmagic-dev \
   libleptonica-dev \
+  ghostscript \
   ocrmypdf
 
 # Download and compile openjpeg2.1

--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ Then build the image:
 
 You can then run the pipeline, mounting any local directories you need access to.
 For example, the command above will mount `/local_files/` on your local machine
-to `/source_files/` in the running container and then execute `iiif_pipeline.py`:
+to `/source_files/` in the running container and then execute `iiif_pipeline.py`,
+using `/tmp` in the container as a destination directory:
 
     $ docker run -v /local_files:/source_files iiif-pipeline python iiif-pipeline.py /source_files /tmp
 
@@ -59,11 +60,14 @@ contains a subdirectory named `master` containing original TIFF files:
 
 This library is designed to be executed from the command line:
 
-    $ iiif-pipeline.py source_directory [--skip] [--replace]
+    $ iiif-pipeline.py source_directory target_directory [--skip] [--replace]
 
-where `source_directory` is a path to the directory described, the
-optional `--skip` flag will skip image files with filenames ending in `_001`,
-and the optional `--replace` flag will replace existing files.
+where `source_directory` is a path to the directory described above and
+`target_directory` is a path at which the derivative and manifest files will be
+created before they are uploaded. The user running the script must own the
+`target_directory`. The optional `--skip` flag will skip image files with
+filenames ending in `_001`, and the optional `--replace` flag will replace
+existing files.
 
 
 ## Configuration

--- a/iiif_pipeline/derivatives.py
+++ b/iiif_pipeline/derivatives.py
@@ -120,7 +120,7 @@ def compress_pdf(identifier, pdf_dir):
     os.rename(output_pdf_path, source_pdf_path)
 
 
-def process_pdf(identifier, pdf_dir):
+def ocr_pdf(identifier, pdf_dir):
     """Add OCR layer using ocrmypdf.
 
     Args:

--- a/iiif_pipeline/derivatives.py
+++ b/iiif_pipeline/derivatives.py
@@ -98,22 +98,14 @@ def create_pdf(files, identifier, pdf_dir, replace=False):
         raise Exception("Error creating PDF: {}".format(e)) from e
 
 
-def compress_pdf(identifier, pdf_dir):
-    """Compress PDF via Ghostscript command line interface and delete original PDF.
-    Delete original PDF when complete, replace compressed PDF with original filename.
+def process_pdf(identifier, pdf_dir):
+    """Add OCR layer and compress PDF using ocrmypdf.
 
     Args:
         identifier (str): Identifier of created PDF file.
         pdf_dir (str): Directory in which to save the PDF file.
     """
-    source_pdf_path = "{}.pdf".format(os.path.join(pdf_dir, identifier))
-    output_pdf_path = "{}_compressed.pdf".format(
-        os.path.join(pdf_dir, identifier))
-    subprocess.call(['gs', '-sDEVICE=pdfwrite', '-dCompatibilityLevel=1.4',
-                     '-dPDFSETTINGS={}'.format('/screen'),
-                     '-dNOPAUSE', '-dQUIET', '-dBATCH',
-                     '-sOutputFile={}'.format(output_pdf_path),
-                     source_pdf_path]
-                    )
-    os.remove(source_pdf_path)
-    os.rename(output_pdf_path, source_pdf_path)
+    pdf_path = "{}.pdf".format(os.path.join(pdf_dir, identifier))
+    subprocess.call(['ocrmypdf', '--optimize', '2',
+                     '--quiet', pdf_path, pdf_path])
+    print(os.stat(pdf_path).st_size)

--- a/iiif_pipeline/derivatives.py
+++ b/iiif_pipeline/derivatives.py
@@ -99,8 +99,9 @@ def create_pdf(files, identifier, pdf_dir, replace=False):
 
 
 def compress_pdf(identifier, pdf_dir):
-    """Compress PDF via Ghostscript command line interface and delete original PDF.
-    Delete original PDF when complete, replace compressed PDF with original filename.
+    """Compress PDF via Ghostscript command line interface.
+
+    Original PDF is replaced with compressed PDF.
 
     Args:
         identifier (str): Identifier of created PDF file.
@@ -120,7 +121,7 @@ def compress_pdf(identifier, pdf_dir):
 
 
 def process_pdf(identifier, pdf_dir):
-    """Add OCR layer and compress PDF using ocrmypdf.
+    """Add OCR layer using ocrmypdf.
 
     Args:
         identifier (str): Identifier of created PDF file.

--- a/iiif_pipeline/derivatives.py
+++ b/iiif_pipeline/derivatives.py
@@ -106,6 +106,5 @@ def process_pdf(identifier, pdf_dir):
         pdf_dir (str): Directory in which to save the PDF file.
     """
     pdf_path = "{}.pdf".format(os.path.join(pdf_dir, identifier))
-    subprocess.call(['ocrmypdf', '--optimize', '2',
+    subprocess.call(['ocrmypdf', '--optimize', '1',
                      '--quiet', pdf_path, pdf_path])
-    print(os.stat(pdf_path).st_size)

--- a/iiif_pipeline/derivatives.py
+++ b/iiif_pipeline/derivatives.py
@@ -98,6 +98,27 @@ def create_pdf(files, identifier, pdf_dir, replace=False):
         raise Exception("Error creating PDF: {}".format(e)) from e
 
 
+def compress_pdf(identifier, pdf_dir):
+    """Compress PDF via Ghostscript command line interface and delete original PDF.
+    Delete original PDF when complete, replace compressed PDF with original filename.
+
+    Args:
+        identifier (str): Identifier of created PDF file.
+        pdf_dir (str): Directory in which to save the PDF file.
+    """
+    source_pdf_path = "{}.pdf".format(os.path.join(pdf_dir, identifier))
+    output_pdf_path = "{}_compressed.pdf".format(
+        os.path.join(pdf_dir, identifier))
+    subprocess.call(['gs', '-sDEVICE=pdfwrite', '-dCompatibilityLevel=1.4',
+                     '-dPDFSETTINGS={}'.format('/screen'),
+                     '-dNOPAUSE', '-dQUIET', '-dBATCH',
+                     '-sOutputFile={}'.format(output_pdf_path),
+                     source_pdf_path]
+                    )
+    os.remove(source_pdf_path)
+    os.rename(output_pdf_path, source_pdf_path)
+
+
 def process_pdf(identifier, pdf_dir):
     """Add OCR layer and compress PDF using ocrmypdf.
 
@@ -106,5 +127,5 @@ def process_pdf(identifier, pdf_dir):
         pdf_dir (str): Directory in which to save the PDF file.
     """
     pdf_path = "{}.pdf".format(os.path.join(pdf_dir, identifier))
-    subprocess.call(['ocrmypdf', '--optimize', '1',
+    subprocess.call(['ocrmypdf', '--optimize', '0', '--output-type', 'pdf',
                      '--quiet', pdf_path, pdf_path])

--- a/iiif_pipeline/pipeline.py
+++ b/iiif_pipeline/pipeline.py
@@ -5,7 +5,7 @@ from configparser import ConfigParser
 import shortuuid
 
 from .clients import ArchivesSpaceClient, AWSClient
-from .derivatives import compress_pdf, create_jp2, create_pdf
+from .derivatives import create_jp2, create_pdf, process_pdf
 from .helpers import cleanup_files, matching_files, refid_dirs
 from .manifests import ManifestMaker
 
@@ -72,7 +72,7 @@ class IIIFPipeline:
                 create_pdf(jp2_files, identifier, pdf_dir, replace)
                 logging.info(
                     "Concatenated PDF created for {}".format(identifier))
-                compress_pdf(identifier, pdf_dir)
+                process_pdf(identifier, pdf_dir)
                 logging.info(
                     "Compressed PDF created for {}".format(identifier))
                 for src_dir, target_dir, file_type in [

--- a/iiif_pipeline/pipeline.py
+++ b/iiif_pipeline/pipeline.py
@@ -5,7 +5,7 @@ from configparser import ConfigParser
 import shortuuid
 
 from .clients import ArchivesSpaceClient, AWSClient
-from .derivatives import compress_pdf, create_jp2, create_pdf, process_pdf
+from .derivatives import compress_pdf, create_jp2, create_pdf, ocr_pdf
 from .helpers import cleanup_files, matching_files, refid_dirs
 from .manifests import ManifestMaker
 
@@ -75,7 +75,7 @@ class IIIFPipeline:
                 compress_pdf(identifier, pdf_dir)
                 logging.info(
                     "Compressed PDF created for {}".format(identifier))
-                process_pdf(identifier, pdf_dir)
+                ocr_pdf(identifier, pdf_dir)
                 logging.info(
                     "OCRed PDF created for {}".format(identifier))
                 for src_dir, target_dir, file_type in [

--- a/iiif_pipeline/pipeline.py
+++ b/iiif_pipeline/pipeline.py
@@ -74,7 +74,7 @@ class IIIFPipeline:
                     "Concatenated PDF created for {}".format(identifier))
                 process_pdf(identifier, pdf_dir)
                 logging.info(
-                    "Compressed PDF created for {}".format(identifier))
+                    "Compressed and OCRed PDF created for {}".format(identifier))
                 for src_dir, target_dir, file_type in [
                         (jp2_dir, "images", "JPEG2000 files"),
                         (pdf_dir, "pdfs", "PDF file"),

--- a/iiif_pipeline/pipeline.py
+++ b/iiif_pipeline/pipeline.py
@@ -5,7 +5,7 @@ from configparser import ConfigParser
 import shortuuid
 
 from .clients import ArchivesSpaceClient, AWSClient
-from .derivatives import create_jp2, create_pdf, process_pdf
+from .derivatives import compress_pdf, create_jp2, create_pdf, process_pdf
 from .helpers import cleanup_files, matching_files, refid_dirs
 from .manifests import ManifestMaker
 
@@ -72,9 +72,12 @@ class IIIFPipeline:
                 create_pdf(jp2_files, identifier, pdf_dir, replace)
                 logging.info(
                     "Concatenated PDF created for {}".format(identifier))
+                compress_pdf(identifier, pdf_dir)
+                logging.info(
+                    "Compressed PDF created for {}".format(identifier))
                 process_pdf(identifier, pdf_dir)
                 logging.info(
-                    "Compressed and OCRed PDF created for {}".format(identifier))
+                    "OCRed PDF created for {}".format(identifier))
                 for src_dir, target_dir, file_type in [
                         (jp2_dir, "images", "JPEG2000 files"),
                         (pdf_dir, "pdfs", "PDF file"),

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ ArchivesSnake==0.9
 boto3==1.16.8
 iiif-prezi==0.3.0
 img2pdf==0.4.0
+ocrmypdf==11.3.3
 Pillow==8.0.1
 pytest==4.3.0
 shortuuid==1.0.1


### PR DESCRIPTION
Uses the [ocrmypdf](https://ocrmypdf.readthedocs.io/en/latest/) library to create an OCR layer and optimize the PDF.

Needs a review of optimization level to ensure parity with previous compression rates. If current image compression stays the same, we should be able to remove JBIG2 encoder from the dependencies.