### PR TITLE
exception handling for jp2 creation

### DIFF
--- a/iiif_pipeline/derivatives.py
+++ b/iiif_pipeline/derivatives.py
@@ -70,7 +70,11 @@ def create_jp2(files, identifier, derivative_dir, replace=False):
                        "-o", derivative_path,
                        "-n", str(layers),
                        "-SOP"] + default_options
-                subprocess.run(cmd)
+                try:
+                    subprocess.run(cmd, check=True)
+                except subprocess.CalledProcessError:
+                    raise Exception(
+                        "Error creating JPEG2000: {} is not a valid TIFF".format(original_file))
             else:
                 raise Exception(
                     "Error creating JPEG2000: {} is not a valid TIFF".format(original_file))

--- a/iiif_pipeline/derivatives.py
+++ b/iiif_pipeline/derivatives.py
@@ -70,11 +70,7 @@ def create_jp2(files, identifier, derivative_dir, replace=False):
                        "-o", derivative_path,
                        "-n", str(layers),
                        "-SOP"] + default_options
-                try:
-                    subprocess.run(cmd, check=True)
-                except subprocess.CalledProcessError:
-                    raise Exception(
-                        "Error creating JPEG2000: {} is not a valid TIFF".format(original_file))
+                subprocess.run(cmd, check=True)
             else:
                 raise Exception(
                     "Error creating JPEG2000: {} is not a valid TIFF".format(original_file))


### PR DESCRIPTION
Adds a try and exception catch to running the subprocess. If there's a CalledProcessError, raise a generic exception pointing to the file.

Pretty simple solution that'll immediately stop processing on the first failure.

Fixes #82 