### PR TITLE
Correctly parse page numbers for troublesome filenames

### DIFF
--- a/iiif_pipeline/helpers.py
+++ b/iiif_pipeline/helpers.py
@@ -65,5 +65,10 @@ def cleanup_dir(dir_path):
 def get_page_number(filepath):
     """Parses a page number from a filename."""
     filename, _ = splitext(basename(filepath))
-    trimmed = filename.rstrip("_me").rstrip("_se")
+    if "_se" in filename:
+        trimmed = filename.split("_se")[0]
+    elif "_me" in filename:
+        trimmed = filename.split("_me")[0]
+    else:
+        trimmed = filename
     return trimmed.split("_")[-1]

--- a/iiif_pipeline/helpers.py
+++ b/iiif_pipeline/helpers.py
@@ -63,7 +63,13 @@ def cleanup_dir(dir_path):
 
 
 def get_page_number(filepath):
-    """Parses a page number from a filename."""
+    """Parses a page number from a filename.
+
+    Presumes that:
+        The page number is preceded by an underscore
+        The page number is  immediately followed by either by `_m`, `_me` or `_se`,
+          or the file extension.
+    """
     filename, _ = splitext(basename(filepath))
     if "_se" in filename:
         trimmed = filename.split("_se")[0]

--- a/iiif_pipeline/helpers.py
+++ b/iiif_pipeline/helpers.py
@@ -67,8 +67,8 @@ def get_page_number(filepath):
     filename, _ = splitext(basename(filepath))
     if "_se" in filename:
         trimmed = filename.split("_se")[0]
-    elif "_me" in filename:
-        trimmed = filename.split("_me")[0]
+    elif "_m" in filename:
+        trimmed = filename.split("_m")[0]
     else:
         trimmed = filename
     return trimmed.split("_")[-1]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ boto3==1.16.8
 iiif-prezi==0.3.0
 img2pdf==0.4.0
 ocrmypdf==11.3.3
-Pillow==8.1.1
+Pillow==8.2.0
 pytest==4.3.0
 shortuuid==1.0.1
 vcrpy==4.1.0

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -63,6 +63,7 @@ def test_get_page_number():
     for filepath, page_number in [
             ("/source_files/73ebb410267f43af884fd158d0427f8f/master/00336.tif", "00336"),
             ("/source_files/73ebb410267f43af884fd158d0427f8f/master/foo_00336.tif", "00336"),
+            ("/source_files/73ebb410267f43af884fd158d0427f8f/master/00336_m.tif", "00336"),
             ("/source_files/73ebb410267f43af884fd158d0427f8f/master/00336_se.tif", "00336"),
             ("/source_files/73ebb410267f43af884fd158d0427f8f/master/00336_me.tif", "00336"),
             ("/source_files/73ebb410267f43af884fd158d0427f8f/master/00336_se-12345.tif", "00336"),

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -64,7 +64,11 @@ def test_get_page_number():
             ("/source_files/73ebb410267f43af884fd158d0427f8f/master/00336.tif", "00336"),
             ("/source_files/73ebb410267f43af884fd158d0427f8f/master/foo_00336.tif", "00336"),
             ("/source_files/73ebb410267f43af884fd158d0427f8f/master/00336_se.tif", "00336"),
-            ("/source_files/73ebb410267f43af884fd158d0427f8f/master/00336_me.tif", "00336")]:
+            ("/source_files/73ebb410267f43af884fd158d0427f8f/master/00336_me.tif", "00336"),
+            ("/source_files/73ebb410267f43af884fd158d0427f8f/master/00336_se-12345.tif", "00336"),
+            ("/source_files/73ebb410267f43af884fd158d0427f8f/master/00336_me-12345.tif", "00336"),
+            ("/source_files/73ebb410267f43af884fd158d0427f8f/master/foo_00336_se-12345.tif", "00336"),
+            ("/source_files/73ebb410267f43af884fd158d0427f8f/master/foo_00336_me-12345.tif", "00336")]:
         assert get_page_number(filepath) == page_number
 
 


### PR DESCRIPTION
Correctly parses page numbers when they're not the last thing in the filename. 

I feel *pretty* good about this, but would be interested in your thoughts on splitting at `_se` and `_m` rather than `rstrip`-ing those strings.

Fixes #86 